### PR TITLE
Removed global proxyUrl #PLUG-573

### DIFF
--- a/CxScan/CxScanV20/services/configReader.ts
+++ b/CxScan/CxScanV20/services/configReader.ts
@@ -230,7 +230,6 @@ export class ConfigReader {
         };
         if (proxyEnabled) {
             proxy = taskLib.getHttpProxyConfiguration();
-            proxyUrl = taskLib.getInput('proxyURL');
             sastProxyUrl = taskLib.getInput('sastProxyUrl');
             scaProxyUrl = taskLib.getInput('scaProxyUrl');
             //add this 


### PR DESCRIPTION
**Below Testing Scenarios are covered for Proxy:**
> **When enableProxy is true**:
      **1.  Global Proxy is provided without SAST and SCA Proxy URL:** 
                      Both SAST and SCA scans will run without Proxy.
                      Gives warning (Proxy is enabled but no proxy settings are defined).
      **2.  Global Proxy is provided with only SCA Proxy URL:**
	             Only SCA Scan will run on Proxy server.
		     SAST scan will run without Proxy.
      **3.  Global Proxy is provided with only SAST Proxy URL:**
		    Only SAST Scan will run on Proxy server.
		    SCA scan will run without Proxy.
     **4.  Only SCA Proxy URL is provided:**
		   Only SCA Scan will run on Proxy server.
		   SAST scan will run without Proxy.
     **5.   Only SAST Proxy URL is provided:**
		  Only SAST Scan will run on Proxy server.
		  SCA scan will run without Proxy. 
     **6.    Global Proxy URL is not provided, SAST and SCA proxy URL's are two different proxy.**
                   SAST scan will run on given respective SAST proxy.
                   SCA scan will run on given respective SCA proxy.

> **When enableProxy is false:**
	Neither SAST nor SCA scans will run through Proxy Server.

