### PR TITLE
ADO pipeline plugin synchronous scan to have a retry number parameter to retry the connection to Checkmarx

### DIFF
--- a/CxScan/CxScanV20/services/configReader.ts
+++ b/CxScan/CxScanV20/services/configReader.ts
@@ -331,6 +331,12 @@ export class ConfigReader {
 
         const postScanAction = taskLib.getInput('postScanAction', false) || '';
         const avoidDuplicateProjectScans = taskLib.getBoolInput('avoidDuplicateScans', false);
+        
+        let rawWaitTime = taskLib.getInput('waitingTimeBeforeRetryScan', false) as any;
+        let retryWaitTime = +rawWaitTime;
+        
+        let rawSCAWaitTime = taskLib.getInput('waitingTimeBeforeRetrySCAScan', false) as any;
+        let retrySCAWaitTime = +rawSCAWaitTime;
 
         let rawTimeout = taskLib.getInput('scanTimeout', false) as any;
 
@@ -373,7 +379,8 @@ export class ConfigReader {
             isEnableScaResolver:taskLib.getBoolInput('isEnableScaResolver', false) || false,
             pathToScaResolver:taskLib.getInput('pathToScaResolver', false) || '',
             scaResolverAddParameters:taskLib.getInput('scaResolverAddParameters', false) || '',
-            scaScanTimeoutInMinutes: scaScanTimeoutInMinutes || undefined
+            scaScanTimeoutInMinutes: scaScanTimeoutInMinutes || undefined,
+            scaWaitTimeForRetryScan: retrySCAWaitTime || undefined
         };       
         
         var isSyncMode = taskLib.getBoolInput('syncMode', false);
@@ -412,6 +419,7 @@ export class ConfigReader {
             engineConfigurationId: ConfigReader.getNumericInput('engineConfigId'),
             postScanActionName: postScanAction,
             avoidDuplicateProjectScans: avoidDuplicateProjectScans,
+            waitTimeForRetryScan : retryWaitTime || undefined
         };
 
         const result: ScanConfig = {
@@ -482,6 +490,9 @@ if (config.sastConfig.isIncremental) {
 if(config.sastConfig.scanTimeoutInMinutes != undefined){
     this.log.info(`Scan timeout in minutes: ${config.sastConfig.scanTimeoutInMinutes}`);
     }
+    if(config.sastConfig.waitTimeForRetryScan != undefined){
+        this.log.info(`Waiting Time Before Retry Scan In Seconds: ${config.sastConfig.waitTimeForRetryScan}`);
+        }
 this.log.info(`Folder exclusions: ${formatOptionalString(config.sastConfig.folderExclusion)}
 Include/Exclude Wildcard Patterns: ${formatOptionalString(config.sastConfig.fileExtension)}
 Is synchronous scan: ${config.isSyncMode}
@@ -550,6 +561,9 @@ if(config.scaConfig.isEnableScaResolver) {
 if(config.scaConfig.scaScanTimeoutInMinutes != undefined) {
     this.log.info(`Scan timeout in minutes: ${config.scaConfig.scaScanTimeoutInMinutes}`);
     }
+    if(config.scaConfig.scaWaitTimeForRetryScan != undefined) {
+        this.log.info(`Waiting time before retry SCA scan in seconds: ${config.scaConfig.scaWaitTimeForRetryScan}`);
+        }
             if (config.scaConfig.vulnerabilityThreshold) {
                 this.log.info(`CxSCA High Threshold: ${config.scaConfig.highThreshold}
 CxSCA Medium Threshold: ${config.scaConfig.mediumThreshold}

--- a/CxScan/CxScanV20/task.json
+++ b/CxScan/CxScanV20/task.json
@@ -259,6 +259,15 @@
       "visibleRule": "enableSastScan = true"
     },
     {
+      "name": "waitingTimeBeforeRetryScan",
+      "type": "string",
+      "label": "Waiting Time Before Retry Scan In Seconds",
+      "required": false,
+      "helpMarkDown": "Wait for specified time before retry scan in seconds.If value is not added then by default waiting time before retry scan in 10 seconds.",
+      "groupName": "scanSettings",
+      "visibleRule": "enableSastScan = true"
+    },
+    {
       "name": "projectcustomfields",
       "type": "string",
       "label": "Project Level Custom Fields",
@@ -635,6 +644,15 @@
       "label": "Scan Timeout In Minutes",
       "required": false,
       "helpMarkDown": "Abort the scan if exceeds specified timeout in minutes ",
+      "groupName": "dependencyScan",
+      "visibleRule": "enableDependencyScan = true"
+    },
+    {
+      "name": "waitingTimeBeforeRetrySCAScan",
+      "type": "string",
+      "label": "Waiting Time Before Retry SCA Scan In Seconds",
+      "required": false,
+      "helpMarkDown": "Wait for specified time before retry SCA scan in seconds.If value is not added then by default waiting time before retry SCA scan in 5 seconds.",
       "groupName": "dependencyScan",
       "visibleRule": "enableDependencyScan = true"
     }


### PR DESCRIPTION
**Changes**
Added 2 configurable parameters waitTimeForRetryScan and scaWaitTimeForRetryScan for SAST and SCA. If user not added values by default it will take time 10 seconds for SAST and 5 second for SAST.

**Test Cases**
**Note** - We cannot reproduce errors so added a debug log to print parameter values

1) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = blank
	Expected - It will take By default value 10 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 10
2) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = invalid value Ex - abcd
	Expected - It will take By default value 10 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 10
3) Create new/use existing SAST project with Waiting Time Before Retry Scan In Seconds = valid value Ex - 60 
	Expected - It will take By default value 60 for SAST scan
	Check Debug Log - Waiting time before retry SAST scan is: 60
4) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = blank
	Expected - It will take By default value 5 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 5
5) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = invalid value Ex - abcd
	Expected - It will take By default value 5 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 5
6) Create new/use existing SCA project with Waiting Time Before Retry SCA Scan In Seconds = valid value Ex - 60 
	Expected - It will take By default value 60 for SCA scan
	Check Debug Log - Waiting time before retry SCA scan is: 60