### PR TITLE
Added validation to check project name not equal to master branch pro…

### DIFF
--- a/CxScan/CxScanV20/services/taskRunner.ts
+++ b/CxScan/CxScanV20/services/taskRunner.ts
@@ -210,6 +210,14 @@ Starting Checkmarx scan`);
         const sastEnabled = taskLib.getBoolInput('enableSastScan', false);
         const dependencyScanEnabled = taskLib.getBoolInput('enableDependencyScan', false);
         let failedCount = 0;
+        let projectName = taskLib.getInput('projectName', false) || '';
+        let masterBranchProject = taskLib.getInput('masterBranchProjectName', false) || '';
+        let enableSastBranching = taskLib.getBoolInput('enableSastBranching', false);
+        if(enableSastBranching && projectName == masterBranchProject)
+        {
+            taskLib.setResult(taskLib.TaskResult.Failed, `Project name(${projectName}) and master branch project name(${masterBranchProject}) should not be same.`);
+            failedCount++;
+        }
         if(sastEnabled && sastWaitTime!=undefined && sastWaitTime.trim() != '')
         {
             if(isNaN(sastWaitTime))


### PR DESCRIPTION
Test Case
- If project name already exists and sast branching enabled then pipeline will fail with error (**Scan cannot be completed. Project with name RP-Test-02 is already exists. Cannot create branched project if project name already exists.**)
- If Master Branch Project name is not exists then pipeline will fail with error (**Scan cannot be completed. Master branch project does not exist: RP-Test-07**)
- If Master Branch Project name and Project Name both are same and if its exists then pipeline will fail with error (**Project name(abc) and master branch project name(abc) should not be same.**)