### PR TITLE
changes related to query result count without not exploitable

### DIFF
--- a/Reports/scripts/cxTabReport.js
+++ b/Reports/scripts/cxTabReport.js
@@ -1005,7 +1005,7 @@ define(["require", "exports", "VSS/Controls", "TFS/DistributedTask/TaskRestClien
                                     //loop through queries and push the relevant query - by severity - to the new list (lookup table)
                                     for (var i = 0; i < queryList.length; i++) {
                                         if (queryList[i].severity.toLowerCase() == severity.name) {
-                                            severityQueryList[queryList[i].name] = queryList[i].resultLength ? queryList[i].resultLength : 1;
+                                            severityQueryList[queryList[i].name] = queryList[i].resultLength;
                                         }
                                     }
                                     return severityQueryList;


### PR DESCRIPTION
**Test Case**
- Create new SAST project using ADO
- Run a scan
- Got SAST results
- Go to Sast web viewer and put some results as Not_Exploitable state
- Run same job from Jenkins

**Expected** 
- vulnerability count on ADO and SAST should be same