### PR TITLE
SAST Fast scan

### DIFF
--- a/CxScan/CxScanV20/services/configReader.ts
+++ b/CxScan/CxScanV20/services/configReader.ts
@@ -425,13 +425,15 @@ export class ConfigReader {
             cacert_chainFilePath: sastCertFilePath,
             projectCustomFields: taskLib.getInput('projectcustomfields', false) || '',
             customFields: ConfigReader.getCustomFieldJSONString(taskLib.getInput('customfields', false), this.log),
-            engineConfigurationId: ConfigReader.getNumericInput('engineConfigId'),
             postScanActionName: postScanAction,
             avoidDuplicateProjectScans: avoidDuplicateProjectScans,
             enableSastBranching : enableBranching,
             masterBranchProjectName : parentBranchProjectName,
-            waitTimeForRetryScan : retryWaitTime || undefined
+            waitTimeForRetryScan : retryWaitTime || undefined,
+            engineConfigurationName : taskLib.getInput('engineConfigId') || ''
         };
+        
+        this.log.info(`engineConfigurationName: ${sastResult.engineConfigurationName}`);
 
         const result: ScanConfig = {
             enableSastScan: taskLib.getBoolInput('enableSastScan', false),
@@ -514,7 +516,6 @@ if(config.sastConfig.scanTimeoutInMinutes != undefined){
         this.log.info(`SAST Comment: ${config.sastConfig.comment}`);
         this.log.info(`Project Custom Fields: ${config.sastConfig.projectCustomFields}`);
         this.log.info(`Scan Custom Fields: ${config.sastConfig.customFields}`);
-        this.log.info(`Engine Configuration Id: ${config.sastConfig.engineConfigurationId}`);
         this.log.info(`Post Scan Action: ${config.sastConfig.postScanActionName}`);
         this.log.info(`Avoid Duplicate Project Scan: ${config.sastConfig.avoidDuplicateProjectScans}`);
             if (config.isSyncMode) {

--- a/CxScan/CxScanV20/services/configReader.ts
+++ b/CxScan/CxScanV20/services/configReader.ts
@@ -425,15 +425,13 @@ export class ConfigReader {
             cacert_chainFilePath: sastCertFilePath,
             projectCustomFields: taskLib.getInput('projectcustomfields', false) || '',
             customFields: ConfigReader.getCustomFieldJSONString(taskLib.getInput('customfields', false), this.log),
+            engineConfigurationId: ConfigReader.getNumericInput('engineConfigId'),
             postScanActionName: postScanAction,
             avoidDuplicateProjectScans: avoidDuplicateProjectScans,
             enableSastBranching : enableBranching,
             masterBranchProjectName : parentBranchProjectName,
-            waitTimeForRetryScan : retryWaitTime || undefined,
-            engineConfigurationName : taskLib.getInput('engineConfigId') || ''
+            waitTimeForRetryScan : retryWaitTime || undefined
         };
-        
-        this.log.info(`engineConfigurationName: ${sastResult.engineConfigurationName}`);
 
         const result: ScanConfig = {
             enableSastScan: taskLib.getBoolInput('enableSastScan', false),
@@ -516,6 +514,7 @@ if(config.sastConfig.scanTimeoutInMinutes != undefined){
         this.log.info(`SAST Comment: ${config.sastConfig.comment}`);
         this.log.info(`Project Custom Fields: ${config.sastConfig.projectCustomFields}`);
         this.log.info(`Scan Custom Fields: ${config.sastConfig.customFields}`);
+        this.log.info(`Engine Configuration Id: ${config.sastConfig.engineConfigurationId}`);
         this.log.info(`Post Scan Action: ${config.sastConfig.postScanActionName}`);
         this.log.info(`Avoid Duplicate Project Scan: ${config.sastConfig.avoidDuplicateProjectScans}`);
             if (config.isSyncMode) {

--- a/CxScan/CxScanV20/task.json
+++ b/CxScan/CxScanV20/task.json
@@ -173,11 +173,12 @@
       "defaultValue": "Default Configuration",
       "helpMarkDown": "Source character encoding for the project.",
       "options": {
-        "Default Configuration": "Default Configuration",
-        "Japanese (Shift-JIS)": "Japanese (Shift-JIS)",
-        "Korean": "Korean",
-        "Multi-language Scan": "Multi-language Scan",
-        "Fast Scan": "Fast Scan (Only for CxSAST Engine version 9.6.3 and above)"
+        "0": "Project Default (Only for CxSAST 9.3.0+)",
+        "1": "Default Configuration",
+        "2": "Japanese (Shift-JIS)",
+        "3": "Korean",
+        "5": "Multi-language Scan",
+        "6": "Fast Scan (Only for CxSAST Engine version 9.6.3+)"
       },
       "visibleRule": "enableSastScan = true"
     },

--- a/CxScan/CxScanV20/task.json
+++ b/CxScan/CxScanV20/task.json
@@ -173,12 +173,11 @@
       "defaultValue": "Default Configuration",
       "helpMarkDown": "Source character encoding for the project.",
       "options": {
-        "1": "Default Configuration",
-        "2": "Japanese (Shift-JIS)",
-        "3": "Korean",
-        "5": "Multi-language Scan",
-        "6": "Improved Scan Flow",
-        "0": "Project Default (Only for CxSAST 9.3.0+)"
+        "Default Configuration": "Default Configuration",
+        "Japanese (Shift-JIS)": "Japanese (Shift-JIS)",
+        "Korean": "Korean",
+        "Multi-language Scan": "Multi-language Scan",
+        "Fast Scan": "Fast Scan (Only for CxSAST Engine version 9.6.3 and above)"
       },
       "visibleRule": "enableSastScan = true"
     },


### PR DESCRIPTION
**Note** - 
1. Test below cases with SAST 9.5, SAST 9.6 & SAST 9.7
2. Test below cases with ADO UI and YAML pipeline both

**Test Case 1**
- Create a SAST new project with **Configuration -> Default Configuration and Override Project Settings = false** 
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Default Configuration**


**Test Case 2**
- Create a SAST new project with **Configuration -> Japanese (Shift-JIS) and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Japanese (Shift-JIS)**


**Test Case 3**
- Create a SAST new project with **Configuration -> Korean and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Korean**

**Test Case 4**
- Create a SAST new project with **Configuration -> Multi-language Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Multi-language Scan**

Test Case 5
- Create a SAST new project with **Configuration -> Fast Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output for SAST Engine Version 9.6.3 and above -> Fast Scan**
**Expected Output for SAST Engine Version 9.6.2 and lower -> Pipeline will fail with error -> 
	The Build Failed : SAST Engine Version 9.6.2 and lower version does not supports Force Scan (Source character encoding Configuration)**


**Test Case 6**
- Open SAST DB and execute below query
	**select * from Config.CxEngineConfiguration**
 
	**update Config.CxEngineConfiguration set IsDefault = 0 where Id = 1**
	**update Config.CxEngineConfiguration set IsDefault = 1 where Id = 2**
	
**Updated Japanese (Shift-JIS) as default**
- Create a SAST new project with **Configuration -> Project Default and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Japanese (Shift-JIS)**

**Test Case 7**
- Run below test case with SAST engive version 9.6.3+
- Open SAST DB and execute below query
	**select * from Config.CxEngineConfiguration**
 
	**update Config.CxEngineConfiguration set IsDefault = 0 where Id = 1**
	**update Config.CxEngineConfiguration set IsDefault = 1 where Id = 2**
	
**Updated Japanese (Shift-JIS) as default**
- Create a SAST new project with **Configuration -> Fast Scan and Override Project Settings = false**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Project Default and Override Project Settings = false**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Korean and Override Project Settings = false**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**


**Test Case 8**
- Create a SAST new project with **Configuration -> Multi-language Scan and Override Project Settings = true**
- Wait till pipeline successful
- Login with SAST server -> Go to Projects & Scans -> Projects -> Check Configuration
**Expected Output -> Multi-language Scan**
- Edit pipeline select **Configuration -> Japanese (Shift-JIS) and Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Japanese (Shift-JIS)**
- Edit pipeline select **Configuration -> Fast Scan** and **Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
- Edit pipeline select **Configuration -> Project Default and Override Project Settings = true**
- Save and run pipeline with same project name
**Expected Output -> Fast Scan**
