### PR TITLE
PLUG-2809 Add free text source character encoding box

### DIFF
--- a/CxScan/CxScanV20/services/configReader.ts
+++ b/CxScan/CxScanV20/services/configReader.ts
@@ -351,7 +351,7 @@ export class ConfigReader {
         
         let scaScanTimeout = taskLib.getInput('scaScanTimeout', false) as any;
         let scaScanTimeoutInMinutes = +scaScanTimeout;        
-        
+
         const scaResult: ScaConfig = {
             scaSastTeam: TeamApiClient.normalizeTeamName(scaTeamName) || '',
             apiUrl: scaServerUrl || '',
@@ -397,6 +397,16 @@ export class ConfigReader {
             generatePDFReport=false;
         }        
 
+        const customValue = taskLib.getInput('customEngineConfigId', false);
+
+        let engineConfigurationId: number;
+
+        if (customValue !== undefined && customValue !== null && customValue.trim() !== '') {
+            engineConfigurationId = Number(customValue);
+        } else {
+            engineConfigurationId = ConfigReader.getNumericInput('engineConfigId')!;
+        }
+
         const sastResult: SastConfig = {
             serverUrl: sastServerUrl || '',
             username: sastUsername || '',
@@ -425,7 +435,7 @@ export class ConfigReader {
             cacert_chainFilePath: sastCertFilePath,
             projectCustomFields: taskLib.getInput('projectcustomfields', false) || '',
             customFields: ConfigReader.getCustomFieldJSONString(taskLib.getInput('customfields', false), this.log),
-            engineConfigurationId: ConfigReader.getNumericInput('engineConfigId'),
+            engineConfigurationId: engineConfigurationId,
             postScanActionName: postScanAction,
             avoidDuplicateProjectScans: avoidDuplicateProjectScans,
             enableSastBranching : enableBranching,

--- a/CxScan/CxScanV20/task.json
+++ b/CxScan/CxScanV20/task.json
@@ -166,20 +166,11 @@
     },
     {
       "name": "engineConfigId",
-      "type": "pickList",
+      "type": "string",
       "label": "Source character encoding (Configuration)",
       "required": false,
-      "groupName": "scanSettings",
-      "defaultValue": 1,
       "helpMarkDown": "Source character encoding for the project.",
-      "options": {
-        "0": "Project Default (Only for CxSAST 9.3.0+)",
-        "1": "Default Configuration",
-        "2": "Japanese (Shift-JIS)",
-        "3": "Korean",
-        "5": "Multi-language Scan",
-        "6": "Fast Scan (Only for CxSAST Engine version 9.6.3+)"
-      },
+      "groupName": "scanSettings",
       "visibleRule": "enableSastScan = true"
     },
     {


### PR DESCRIPTION
✔ 1. Engine Config ID now supports custom ID's instead of a set table and is a free text box

✔ 2. Verified as a pre-release version on ADO.
Existing ID -> [Info] Using engine configuration: Multi-language Scan (ID: 5) SUCCESS
custom ID -> [Info] Using engine configuration: Custom Config (ID: 9) SUCCESS
Non Existing ID -> ##[debug]Engine configuration ID 10 not found. ##[error]Scan cannot be completed. The Build Failed : Selected source character encoding Configuration ID -> 10 not found on server.
ID 6 -> [Info] Using engine configuration: Fast Scan (ID: 6) ##[error]Version 9.6.1 does not support engine configuration: Fast Scan (ID: 7). SUCCESS
Don't pass any engineConfID param -> Uses project default config SUCCESS